### PR TITLE
Use Unique Ids with mysql.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="ASMPluginConfiguration">
+    <asm skipDebug="false" skipFrames="false" skipCode="false" expandFrames="false" />
+    <groovy codeStyle="LEGACY" />
+  </component>
   <component name="EntryPointsManager">
     <entry_points version="2.0" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>
-

--- a/ant.xml
+++ b/ant.xml
@@ -25,7 +25,7 @@
     <target name="compile" depends="clean">
         <buildnumber/>
         <mkdir dir="${classes.dir}"/>
-        <javac srcdir="${src.dir}" destdir="${classes.dir}" classpathref="classpath" debug="true" debuglevel="lines,vars,source" deprecation="true"/>
+        <javac includeantruntime="false" srcdir="${src.dir}" destdir="${classes.dir}" classpathref="classpath" debug="true" debuglevel="lines,vars,source" deprecation="true"/>
     </target>
 
     <target name="jar" depends="compile,injectVersion">

--- a/src/defaults.yml
+++ b/src/defaults.yml
@@ -5,3 +5,4 @@ mail:
   book:
     currency: GOLD_INGOT
     amount: 10
+mailUniverse: survival

--- a/src/no/runsafe/mailbox/events/PlayerInteract.java
+++ b/src/no/runsafe/mailbox/events/PlayerInteract.java
@@ -1,8 +1,10 @@
 package no.runsafe.mailbox.events;
 
+import no.runsafe.framework.api.IConfiguration;
 import no.runsafe.framework.api.block.IBlock;
 import no.runsafe.framework.api.event.player.IPlayerInteractEvent;
 import no.runsafe.framework.api.event.player.IPlayerRightClickBlock;
+import no.runsafe.framework.api.event.plugin.IConfigurationChanged;
 import no.runsafe.framework.api.player.IPlayer;
 import no.runsafe.framework.minecraft.Item;
 import no.runsafe.framework.minecraft.event.player.RunsafePlayerInteractEvent;
@@ -10,7 +12,7 @@ import no.runsafe.framework.minecraft.item.meta.RunsafeMeta;
 import no.runsafe.mailbox.MailHandler;
 import no.runsafe.mailbox.MailboxBlocks;
 
-public class PlayerInteract implements IPlayerInteractEvent, IPlayerRightClickBlock
+public class PlayerInteract implements IPlayerInteractEvent, IPlayerRightClickBlock, IConfigurationChanged
 {
 	public PlayerInteract(MailHandler mailHandler, MailboxBlocks blocks)
 	{
@@ -19,8 +21,17 @@ public class PlayerInteract implements IPlayerInteractEvent, IPlayerRightClickBl
 	}
 
 	@Override
+	public void OnConfigurationChanged(IConfiguration configuration)
+	{
+		this.mailUniverse = configuration.getConfigValueAsString("mailUniverse");
+	}
+
+	@Override
 	public void OnPlayerInteractEvent(RunsafePlayerInteractEvent event)
 	{
+		if (!mailUniverse.equals(event.getPlayer().getWorld().getUniverse().getName()))
+			return;
+
 		if (event.hasItem())
 		{
 			RunsafeMeta item = event.getItemStack();
@@ -52,4 +63,5 @@ public class PlayerInteract implements IPlayerInteractEvent, IPlayerRightClickBl
 
 	private final MailHandler mailHandler;
 	private final MailboxBlocks blocks;
+	private String mailUniverse;
 }

--- a/src/no/runsafe/mailbox/repositories/MailPackageRepository.java
+++ b/src/no/runsafe/mailbox/repositories/MailPackageRepository.java
@@ -4,6 +4,8 @@ import no.runsafe.framework.api.IServer;
 import no.runsafe.framework.api.database.*;
 import no.runsafe.framework.minecraft.inventory.RunsafeInventory;
 
+import javax.annotation.Nonnull;
+
 public class MailPackageRepository extends Repository
 {
 	public MailPackageRepository(IServer server)
@@ -11,6 +13,7 @@ public class MailPackageRepository extends Repository
 		this.server = server;
 	}
 
+	@Nonnull
 	@Override
 	public String getTableName()
 	{
@@ -42,6 +45,7 @@ public class MailPackageRepository extends Repository
 		this.database.execute("DELETE FROM mail_packages WHERE ID = ?", packageID);
 	}
 
+	@Nonnull
 	@Override
 	public ISchemaUpdate getSchemaUpdateQueries()
 	{

--- a/src/no/runsafe/mailbox/repositories/MailboxObjectRepository.java
+++ b/src/no/runsafe/mailbox/repositories/MailboxObjectRepository.java
@@ -2,7 +2,6 @@ package no.runsafe.mailbox.repositories;
 
 import no.runsafe.framework.api.ILocation;
 import no.runsafe.framework.api.IWorld;
-import no.runsafe.framework.api.database.IDatabase;
 import no.runsafe.framework.api.database.ISchemaUpdate;
 import no.runsafe.framework.api.database.Repository;
 import no.runsafe.framework.api.database.SchemaUpdate;
@@ -12,9 +11,8 @@ import java.util.List;
 
 public class MailboxObjectRepository extends Repository
 {
-	public MailboxObjectRepository(IDatabase database)
+	public MailboxObjectRepository()
 	{
-		this.database = database;
 	}
 
 	@Nonnull
@@ -49,6 +47,4 @@ public class MailboxObjectRepository extends Repository
 
 		return update;
 	}
-
-	private final IDatabase database;
 }

--- a/src/no/runsafe/mailbox/repositories/MailboxObjectRepository.java
+++ b/src/no/runsafe/mailbox/repositories/MailboxObjectRepository.java
@@ -7,6 +7,7 @@ import no.runsafe.framework.api.database.ISchemaUpdate;
 import no.runsafe.framework.api.database.Repository;
 import no.runsafe.framework.api.database.SchemaUpdate;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
 public class MailboxObjectRepository extends Repository
@@ -16,6 +17,7 @@ public class MailboxObjectRepository extends Repository
 		this.database = database;
 	}
 
+	@Nonnull
 	@Override
 	public String getTableName()
 	{
@@ -32,6 +34,7 @@ public class MailboxObjectRepository extends Repository
 		return database.queryLocations("SELECT `world`, `x`, `y`, `z` FROM `mailbox_blocks` WHERE world=?", world.getName());
 	}
 
+	@Nonnull
 	@Override
 	public ISchemaUpdate getSchemaUpdateQueries()
 	{

--- a/src/no/runsafe/mailbox/repositories/MailboxObjectRepository.java
+++ b/src/no/runsafe/mailbox/repositories/MailboxObjectRepository.java
@@ -51,5 +51,4 @@ public class MailboxObjectRepository extends Repository
 	}
 
 	private final IDatabase database;
-
 }

--- a/src/no/runsafe/mailbox/repositories/MailboxRepository.java
+++ b/src/no/runsafe/mailbox/repositories/MailboxRepository.java
@@ -1,7 +1,6 @@
 package no.runsafe.mailbox.repositories;
 
 import no.runsafe.framework.api.IServer;
-import no.runsafe.framework.api.database.IDatabase;
 import no.runsafe.framework.api.database.ISchemaUpdate;
 import no.runsafe.framework.api.database.Repository;
 import no.runsafe.framework.api.database.SchemaUpdate;

--- a/src/no/runsafe/mailbox/repositories/MailboxRepository.java
+++ b/src/no/runsafe/mailbox/repositories/MailboxRepository.java
@@ -8,6 +8,8 @@ import no.runsafe.framework.api.database.SchemaUpdate;
 import no.runsafe.framework.api.player.IPlayer;
 import no.runsafe.framework.minecraft.inventory.RunsafeInventory;
 
+import javax.annotation.Nonnull;
+
 public class MailboxRepository extends Repository
 {
 	public MailboxRepository(IServer server)
@@ -15,6 +17,7 @@ public class MailboxRepository extends Repository
 		this.server = server;
 	}
 
+	@Nonnull
 	@Override
 	public String getTableName()
 	{
@@ -42,6 +45,7 @@ public class MailboxRepository extends Repository
 		);
 	}
 
+	@Nonnull
 	@Override
 	public ISchemaUpdate getSchemaUpdateQueries()
 	{


### PR DESCRIPTION
- Use Unique IDs to store player mailboxes in mysql rather than usernames.  

- Only let players use mailboxes if they're in the survival universe.  
    Stops players from being able to spawn in and use mailboxes in creative.